### PR TITLE
Add bounding box propagation across frames + plot box trajectory

### DIFF
--- a/src/Pipfile
+++ b/src/Pipfile
@@ -4,7 +4,7 @@ verify_ssl = true
 name = "pypi"
 
 [packages]
-open3d = "==0.13.0"
+open3d = "==0.14.1"
 numpy = "==1.22.2"
 nuscenes-devkit = "==1.1.9"
 matplotlib = "==3.5.1"

--- a/src/annotation_editing.py
+++ b/src/annotation_editing.py
@@ -159,18 +159,6 @@ class Annotation:
 		self.min_confidence = 0
 		self.current_confidence = 0
 
-		""" confidence threshold in edit mode """
-		# # Set up a widget to specify a minimum annotation confidence
-		# confidence_select = gui.NumberEdit(gui.NumberEdit.INT)
-		# confidence_select.set_limits(0,100)
-		# confidence_select.set_value(50)
-		# confidence_select.set_on_value_changed(self.on_confidence_switch)
-
-		# # Add confidence select widget to horizontal
-		# confidence_select_layout = gui.Horiz()
-		# confidence_select_layout.add_child(gui.Label("Specify (Pred) Confidence Threshold"))
-		# confidence_select_layout.add_child(confidence_select)
-
 		# Add combobox to switch between predicted and ground truth
 		self.bounding_toggle = gui.Combobox()
 		self.bounding_toggle.add_item("Predicted")
@@ -1420,7 +1408,6 @@ class Annotation:
 			global_box = self.create_box_metadata(bounding_box.get_center(), size, Quaternion(matrix=bounding_box.R).elements, box["annotation"],
 												  box["confidence"], box["id"], box["internal_pts"], box["data"])
 
-
 			global_new_gt_boxes.append(global_box)
 		
 		global_new_pred_boxes = []
@@ -1439,8 +1426,6 @@ class Annotation:
 			
 			global_box = self.create_box_metadata(bounding_box.get_center(), size, Quaternion(matrix=bounding_box.R).elements, box["annotation"],
 												  box["confidence"], "", 0, box["data"])
-
-
 
 			global_new_pred_boxes.append(global_box)
 
@@ -1507,20 +1492,14 @@ class Annotation:
 			ego_box = self.create_box_metadata(box_to_rotate.center, size, result.elements, box["annotation"], box["confidence"], "", 0, box["data"])
 			ego_box['data']['prev_origin'] = box['origin'] # stores the previous origin in the global frame
 			
-			
 			self.propagated_pred_boxes.append(ego_box)
 
-
-		# should have propagate = true
-		# print("propagated gt boxes: ", self.propagated_gt_boxes)
-		# print("propagated pred boxes: ", self.propagated_pred_boxes)
-		# print("prev gt boxes: ", prev_gt_boxes)
-		# print("prev pred boxes: ", prev_pred_boxes)
 
 		new_val = self.frame_num + 1
 		self.on_frame_switch(new_val)
 
 	def set_velocity(self):
+		# set the velocity based on the difference in coordinates between the current and previous frame
 		current_id = self.previous_index
 		if current_id == -1:
 			return
@@ -1742,7 +1721,6 @@ class Annotation:
 			self.box_indices.append(box[ANNOTATION] + str(i)) #used to reference specific boxes in scene
 			self.boxes_in_scene.append(bounding_box)
 
-			# might be useful later
 			# if box[CONFIDENCE] < 100 and self.show_score:
 			# 	label = self.scene_widget.add_3d_label(bounding_box.center, str(box[CONFIDENCE]))
 			# 	label.color = gui.Color(1.0,0.0,0.0)

--- a/src/lct.py
+++ b/src/lct.py
@@ -987,7 +987,12 @@ class Window:
         frame = cv2.imread(os.path.join(image_folder, images[0]))
         height, width, layers = frame.shape
 
-        video = cv2.VideoWriter(video_name, _fourcc, 3, (width, height))
+        if self.num_frames % 2 == 0:
+            video = cv2.VideoWriter(video_name, _fourcc, 2, (width, height))
+        elif self.num_frames % 3 == 0:
+            video = cv2.VideoWriter(video_name, _fourcc, 3, (width, height))
+        else:
+            video = cv2.VideoWriter(video_name, _fourcc, 1, (width, height))
 
         for image in images:
             video.write(cv2.imread(os.path.join(image_folder, image)))

--- a/src/lct.py
+++ b/src/lct.py
@@ -987,7 +987,7 @@ class Window:
         frame = cv2.imread(os.path.join(image_folder, images[0]))
         height, width, layers = frame.shape
 
-        video = cv2.VideoWriter(video_name, _fourcc, 2, (width,height))
+        video = cv2.VideoWriter(video_name, _fourcc, 3, (width, height))
 
         for image in images:
             video.write(cv2.imread(os.path.join(image_folder, image)))

--- a/src/lct.py
+++ b/src/lct.py
@@ -1066,7 +1066,7 @@ class Window:
     def on_annotation_start(self):
         self.controls.close()
         #self.image_window.close()
-        annotation_object = edit.Annotation(self.widget3d, self.pointcloud_window, self.frame_extrinsic, self.boxes,
+        annotation_object = edit.Annotation(self.widget3d, self.pointcloud_window, self.frame_extrinsic, self.boxes, self.pred_boxes,
                                             self.boxes_to_render, self.boxes_in_scene, self.box_indices,
                                             self.all_pred_annotations, self.path_string, self.color_map, self.pred_color_map,
                                             self.image_window, self.image_widget, self.lct_path, self.frame_num, self.camera_sensors, self.lidar_sensors)

--- a/src/lct.py
+++ b/src/lct.py
@@ -1063,12 +1063,12 @@ class Window:
     
     # Sets program to annotation editing mode, see annotation_editing.py
     def on_annotation_start(self):
-    	self.controls.close()
-    	#self.image_window.close()
-    	annotation_object = edit.Annotation(self.widget3d, self.pointcloud_window, self.frame_extrinsic, self.boxes,
+        self.controls.close()
+        #self.image_window.close()
+        annotation_object = edit.Annotation(self.widget3d, self.pointcloud_window, self.frame_extrinsic, self.boxes,
                                             self.boxes_to_render, self.boxes_in_scene, self.box_indices,
                                             self.all_pred_annotations, self.path_string, self.color_map, self.pred_color_map,
-                                            self.image_window, self.image_widget, self.lct_path, self.frame_num, self.camera_sensors)
+                                            self.image_window, self.image_widget, self.lct_path, self.frame_num, self.camera_sensors, self.lidar_sensors)
 
 
 

--- a/src/lct.py
+++ b/src/lct.py
@@ -202,7 +202,7 @@ class Window:
         self.pred_check_horiz = []
         self.all_pred_annotations = []
         for i in range(0, self.pred_frames):
-            boxes = json.load(open(os.path.join(self.lct_path,"bounding", str(i), "boxes.json")))
+            boxes = json.load(open(os.path.join(self.lct_path,"pred_bounding", str(i), "boxes.json")))
             for box in boxes['boxes']:
                 if box['annotation'] not in self.pred_color_map:
                     self.all_pred_annotations.append(box['annotation'])
@@ -221,7 +221,7 @@ class Window:
                     horiz.add_child(gui.Label("Count: 0"))
                     self.pred_check_horiz.append(horiz)
         if self.pred_frames > 0:
-            self.pred_boxes = json.load(open(os.path.join(self.lct_path ,"bounding", str(self.frame_num), "boxes.json")))
+            self.pred_boxes = json.load(open(os.path.join(self.lct_path ,"pred_bounding", str(self.frame_num), "boxes.json")))
 
         # Horizontal widget where we will insert our drop down menu
         sensor_switch_layout = gui.Horiz()
@@ -497,7 +497,7 @@ class Window:
             count_widget.text = "Count: " + str(count_num)
         
         if self.pred_frames > 0:
-            self.pred_boxes = json.load(open(os.path.join(self.lct_path ,"bounding", str(self.frame_num), "boxes.json")))
+            self.pred_boxes = json.load(open(os.path.join(self.lct_path ,"pred_bounding", str(self.frame_num), "boxes.json")))
             #Update the counters for predicted boxes
             for horiz_widget in self.pred_check_horiz:
                 children = horiz_widget.get_children()
@@ -970,7 +970,7 @@ class Window:
         for j in range(0, self.num_frames):
             boxes = json.load(open(os.path.join(self.lct_path , "bounding", str(j), "boxes.json")))
             try:
-                pred_boxes = json.load(open(os.path.join(self.lct_path , "bounding", str(j), "boxes.json")))
+                pred_boxes = json.load(open(os.path.join(self.lct_path , "pred_bounding", str(j), "boxes.json")))
             except FileNotFoundError:
                 layout.add_child(gui.Label("Error reading predicted data"))
                 window.add_child(layout)

--- a/src/lct.py
+++ b/src/lct.py
@@ -130,7 +130,7 @@ class Window:
         self.path_string = os.path.join(self.lct_path ,"bounding", str(self.frame_num), "boxes.json")
         self.boxes = json.load(open(self.path_string))
         # num of frames available to display
-        frames_available = [entry for entry in os.scandir(os.path.join(self.lct_path, "bounding"))]
+        frames_available = [entry for entry in os.scandir(os.path.join(self.lct_path, "bounding")) if entry.name != ".DS_Store"] # ignore .DS_Store (MacOS)
         self.num_frames = len(frames_available)
         # List to store bounding boxes as NuScenes Box Objects
         self.n_boxes = []
@@ -460,7 +460,7 @@ class Window:
                         color, 2)
 
                 #Only render confidence if this isnt at GT box        
-                if b[CONFIDENCE] < 100 and self.show_score:
+                if b[CONFIDENCE] <= 100 and self.show_score:
                     cv2.putText(self.image, str(b[CONFIDENCE]), (int(corners.T[0][0]), int(corners.T[1][1])), cv2.FONT_HERSHEY_SIMPLEX ,1, (255,0,0), 2)
 
         new_image = o3d.geometry.Image(self.image)
@@ -641,7 +641,7 @@ class Window:
 
             self.box_indices.append(box[ANNOTATION] + str(i)) #used to reference specific boxes in scene
             self.boxes_in_scene.append(bounding_box)
-            if box[CONFIDENCE] < 100 and self.show_score:
+            if box[CONFIDENCE] <= 100 and self.show_score:
                 label = self.widget3d.add_3d_label(bounding_box.center, str(box[CONFIDENCE]))
                 label.color = gui.Color(1.0,0.0,0.0)
                 self.label_list.append(label)

--- a/src/lct.py
+++ b/src/lct.py
@@ -73,7 +73,7 @@ def parse_options():
 
 class Window:
     MENU_IMPORT = 1
-    def __init__(self, lct_dir):
+    def __init__(self, lct_dir, frame_num=0):
         np.set_printoptions(precision=15)
 
         # Create the objects for the 3 windows that appear when running the application
@@ -125,7 +125,7 @@ class Window:
         # image widget used to draw an image onto our image window
         self.image_widget = gui.ImageWidget()
 
-        self.frame_num = 0
+        self.frame_num = frame_num
         # dictionary that stores the imported JSON file that respresents the annotations in the current frame
         self.path_string = os.path.join(self.lct_path ,"bounding", str(self.frame_num), "boxes.json")
         self.boxes = json.load(open(self.path_string))
@@ -244,6 +244,7 @@ class Window:
         # Set up a widget to switch between frames
         self.frame_select = gui.NumberEdit(gui.NumberEdit.INT)
         self.frame_select.set_limits(0, self.num_frames)
+        self.frame_select.set_value(self.frame_num)
         self.frame_select.set_on_value_changed(self.on_frame_switch)
 
         # Add a frame switching widget to another horizontal widget

--- a/src/nuscenes-ct.py
+++ b/src/nuscenes-ct.py
@@ -155,7 +155,7 @@ def extract_bounding(nusc, sample, frame_num, output_path):
         
     dataformat_utils.create_frame_bounding_directory(output_path, frame_num, origins, sizes, rotations, annotation_names, confidences, instance_tokens, num_lidar_pts, data={"ann_token":ann_tokens})
 
-def extract_pred_bounding(pred_path, nusc, scene_token, sample, output_path, pred_data):
+def extract_pred_bounding(nusc, scene_token, sample, output_path, pred_data):
     """Similar to extract_bounding, but specifically to read in predicted data given by a user
     Args:
         pred_path: Path to predicated data provided by user
@@ -205,7 +205,7 @@ def extract_pred_bounding(pred_path, nusc, scene_token, sample, output_path, pre
             rotations.append(box.orientation.q.tolist())
             annotation_names.append(data['detection_name'])
             confidences.append(int(data['detection_score'] * 100))
-        dataformat_utils.create_frame_bounding_directory(output_path, frame_num, origins, sizes, rotations, annotation_names, confidences, True)
+        dataformat_utils.create_frame_bounding_directory(output_path, frame_num, origins, sizes, rotations, annotation_names, confidences, None, None, predicted=True)
         frame_num += 1
 
 def extract_rgb(nusc, sample, frame_num, target_path):
@@ -323,7 +323,7 @@ def convert_dataset(output_path, scene_name, pred_data):
 
     if pred_data != {}:
         print('Extracting predicted bounding boxes...')
-        extract_pred_bounding(pred_path, nusc, scene_token, sample, output_path, pred_data)
+        extract_pred_bounding(nusc, scene_token, sample, output_path, pred_data)
 
 
 

--- a/src/nuscenes-ct.py
+++ b/src/nuscenes-ct.py
@@ -191,6 +191,8 @@ def extract_pred_bounding(nusc, scene_token, sample, output_path, pred_data):
         rotations = []
         annotation_names = []
         confidences = []
+        velocities = []
+        attributes = []
 
         # Ego Frame data for conversion
         sample = nusc.get('sample', sample_token)
@@ -205,7 +207,10 @@ def extract_pred_bounding(nusc, scene_token, sample, output_path, pred_data):
             rotations.append(box.orientation.q.tolist())
             annotation_names.append(data['detection_name'])
             confidences.append(int(data['detection_score'] * 100))
-        dataformat_utils.create_frame_bounding_directory(output_path, frame_num, origins, sizes, rotations, annotation_names, confidences, None, None, predicted=True)
+            velocities.append(data['velocity'])
+            attributes.append(data['attribute_name'])
+        aux_data = {"pred_velocity":velocities, "attribute":attributes}
+        dataformat_utils.create_frame_bounding_directory(output_path, frame_num, origins, sizes, rotations, annotation_names, confidences, None, None, predicted=True, data=aux_data)
         frame_num += 1
 
 def extract_rgb(nusc, sample, frame_num, target_path):

--- a/src/nuscenes-ct.py
+++ b/src/nuscenes-ct.py
@@ -150,8 +150,8 @@ def extract_bounding(nusc, sample, frame_num, output_path):
         rotations.append(box.orientation.q.tolist())
         annotation_names.append(annotation_metadata['category_name'])
 
-        # Confidence for ground truth data is always 100
-        confidences.append(100)
+        # Confidence for ground truth data is always 101 # changed this to 101 since predictions may have confidence of 100
+        confidences.append(101)
         
     dataformat_utils.create_frame_bounding_directory(output_path, frame_num, origins, sizes, rotations, annotation_names, confidences, instance_tokens, num_lidar_pts, data={"ann_token":ann_tokens})
 

--- a/src/nuscenes-ct.py
+++ b/src/nuscenes-ct.py
@@ -209,6 +209,7 @@ def extract_pred_bounding(nusc, scene_token, sample, output_path, pred_data):
             confidences.append(int(data['detection_score'] * 100))
             velocities.append(data['velocity'])
             attributes.append(data['attribute_name'])
+        # auxiliary data to export predictions
         aux_data = {"pred_velocity":velocities, "attribute":attributes}
         dataformat_utils.create_frame_bounding_directory(output_path, frame_num, origins, sizes, rotations, annotation_names, confidences, None, None, predicted=True, data=aux_data)
         frame_num += 1

--- a/src/nuscenes-rt.py
+++ b/src/nuscenes-rt.py
@@ -169,28 +169,6 @@ def extract_frame(frame_num, input_path):
         print("Error in reading pred_bounding")
 
     for i in range(len(pred_bounding["boxes"])):
-        # TODO: Check if this is correct
-        # {
-        #     "sample_token": "fd8420396768425eabec9bdddf7e64b6",
-        #     "translation": [238.57214252174225, 913.5663813237325, 0.9172307699265726],
-        #     "size": [1.8871897459030151, 4.666365146636963, 1.6081377267837524],
-        #     "rotation": [-0.0540253886373565, -0.014531088421748212, -0.005025391842621043, -0.9984211788061649],
-        #     "velocity": [5.048375841727712e-09, -5.2203639789370956e-09],
-        #     "detection_name": "car",
-        #     "detection_score": 0.8652197122573853,
-        #     "attribute_name": "vehicle.parked"
-        # }
-
-        # {
-        #     "origin": [-22.050718317067304, 3.3065296145025136, 1.0352662056374502],
-        #     "size": [1.8986321687698364, 4.532073974609375, 1.7502126693725586],
-        #     "rotation": [0.0017772452267606764, -0.023118258647961677, 0.0015290054192990087, -0.9997299883763203],
-        #     "annotation": "car",
-        #     "confidence": 75,
-        #     "data": {
-        #                 "propagate": False
-        #             }
-        # }
         pred_data = {}
         # Reverting bounding box
         bounding_box = pred_bounding["boxes"][i]
@@ -284,12 +262,6 @@ if __name__ == "__main__":
         instance = {}
         for i in range(len(data)):
             instance[data[i]["token"]] = data[i]
-    # if pred_path != "":
-    #     with open(pred_path + "/predictions.json") as f:
-    #         data = json.load(f)
-    #         pred = {}
-    #         for i in range(len(data)):
-    #             pred[data[i]["token"]] = data[i]
     # Recreating annotation and instance
     new_annotation = {}
     new_instance = {}

--- a/src/utils/dataformat_utils.py
+++ b/src/utils/dataformat_utils.py
@@ -194,7 +194,7 @@ def create_frame_bounding_directory(path, frame_num, origins, sizes, rotations, 
         if not predicted:
             box['id'] = ids[i]
             box['internal_pts'] = internal_points[i]
-        box['data'] = {}
+        box['data'] = {'propagate': False}
         if data:
             for k in data.keys():
                 box['data'][k] = data[k][i]

--- a/src/utils/dataformat_utils.py
+++ b/src/utils/dataformat_utils.py
@@ -191,8 +191,9 @@ def create_frame_bounding_directory(path, frame_num, origins, sizes, rotations, 
         box['rotation'] = rotations[i]
         box['annotation'] = annotation_names[i]
         box['confidence'] = confidences[i]
-        box['id'] = ids[i]
-        box['internal_pts'] = internal_points[i]
+        if not predicted:
+            box['id'] = ids[i]
+            box['internal_pts'] = internal_points[i]
         box['data'] = {}
         if data:
             for k in data.keys():

--- a/src/utils/testing.py
+++ b/src/utils/testing.py
@@ -76,7 +76,11 @@ def check_inside_cameras(path):
         has_ex = False
         has_jpg = True
         # Files in cameras
+        if dir == ".DS_Store":
+            continue # check for MacOS
         for file in os.listdir(os.path.join(path, dir)):
+            if file == ".DS_Store":
+                continue # check for MacOS
             if file == "extrinsics.json": 
                 if not has_ex: 
                     has_ex = True
@@ -110,7 +114,11 @@ def check_inside_pointcloud(path):
     is_verified = True
 
     for dir in os.listdir(path):
+        if dir == ".DS_Store":
+            continue # check for MacOS
         for file in os.listdir(os.path.join(path, dir)):
+            if file == ".DS_Store":
+                continue # check for MacOS
             extension = file[-4:]
             if extension != ".pcd":
                 is_verified = False
@@ -135,7 +143,11 @@ def check_inside_bounding(path):
         has_description = False
         has_boxes = False
         # Loop through files in frame
+        if dir == ".DS_Store":
+            continue # check for MacOS
         for file in os.listdir(os.path.join(path, dir)):
+            if file == ".DS_Store":
+                continue # check for MacOS
             if has_boxes and has_description:
                 is_verified = False
                 print("directory " + dir + " has multiple description.JSON/boxes.json files")
@@ -164,6 +176,8 @@ def check_inside_ego(path):
     is_verified = True
 
     for file in os.listdir(path):
+        if file == ".DS_Store":
+            continue # check for MacOS
         if not file[-5:] == ".json":
             is_verified = False
             print("There is a file in the ego directory that is not a json file")


### PR DESCRIPTION
## Changes
#### [annotation_editing.py]
- Added bounding box propagation across frames – this uses a new ‘propagate’ flag in the ReBound data format.
- Updated UI of edit mode – added options to change frames, propagate newly added boxes, set box velocity, see track_id of boxes, switch predicted boxes to 101 confidence for active learning, and an option to see the trajectory of a box across frames (to help eliminate noise in the GT dataset).
#### [lct.py]
- Added an option to export a BEV video of the LiDAR pointcloud.
#### [nuscenes-ct.py, nuscenes-rt.py]
- Fixed export of predicted data when using the nuscenes scripts.
#### [General]
- Altered a few scripts to support macOS – ReBound now runs on Intel and ARM Macs.
- Bug fixes.
